### PR TITLE
Register tempfile for deletion on JVM exit

### DIFF
--- a/src/loom/io.clj
+++ b/src/loom/io.clj
@@ -129,6 +129,7 @@
         (.write w ^String data))
       (with-open [w (java.io.FileOutputStream. tmp)]
         (.write w ^bytes data)))
+    (.deleteOnExit tmp)
     (open tmp)))
 
 (defn render-to-bytes


### PR DESCRIPTION
`loom.io/open-data` creates a tempfile, but never registers it for deletion
with `.deleteOnExit`. This leaves a potentially large number of files in the
system tempdir.

From the JavaDocs for File.createTempFile():

> This method provides only part of a temporary-file facility. To
> arrange for a file created by this method to be deleted automatically,
> use the deleteOnExit() method.

This is a truly trivial patch, but since you folks are CA-only, I'll mention
that I have also signed the Clojure CA.

Thanks!
