### PR TITLE
NamedGraph, attempt #2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,6 @@
   :dependencies [[org.clojure/clojure "1.4.0"]]
   :url "https://github.com/aysylu/loom"
   :profiles {:dev 
-             {:dependencies [[org.clojure/clojure "1.5.1"]]}}
+             {:dependencies [[org.clojure/clojure "1.6.0"]]}}
   :aliases {"release" ["do" "clean," "with-profile" "default" "deploy" "clojars"]}
   :aot [loom.graph])

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,9 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.4.0"]]
   :url "https://github.com/aysylu/loom"
-  :profiles {:dev 
-             {:dependencies [[org.clojure/clojure "1.6.0"]]}}
+  :profiles {:dev
+             {:dependencies [[org.clojure/clojure "1.6.0"]
+                             [criterium "0.4.3"]
+                             [org.clojure/test.check "0.5.8"]]}}
   :aliases {"release" ["do" "clean," "with-profile" "default" "deploy" "clojars"]}
   :aot [loom.graph])

--- a/src/loom/graph.clj
+++ b/src/loom/graph.clj
@@ -31,7 +31,7 @@ on adjacency lists."
   (add-edges* [g edges] "Add edges to graph g. See add-edges")
   (remove-nodes* [g nodes] "Remove nodes from graph g. See remove-nodes")
   (remove-edges* [g edges] "Removes edges from graph g. See remove-edges")
-  (rename-nodes* [g old-names new-names attr-processor] "Rename nodes in g. 
+  (rename-nodes* [g old-names new-names attr-processor] "Rename nodes in g.
                                                         (defn attr-processor [attr-map old-names new-names] ...)")
   (remove-all [g] "Removes all nodes and edges from graph g"))
 
@@ -61,9 +61,9 @@ on adjacency lists."
   (remove-edges* g edges))
 
 (defn rename-nodes
-  "Rename nodes in g. Sequentially renames, thus cannot handle 
+  "Rename nodes in g. Sequentially renames, thus cannot handle
   name swapping; do not use as (rename-nodes g [1 2] [2 1]), it will
-  not operate correctly. If such a thing is necessary, gensym 
+  not operate correctly. If such a thing is necessary, gensym
   temporary names."
   [g & rst]
   (let [oldn (first rst)
@@ -117,7 +117,7 @@ on adjacency lists."
     :successors (fn
                  ([g] (partial successors g))
                  ([g node] (get-in g [:adj node])))}
-   
+
    ;; Weighted graphs store adjacencies as {node {neighbor weight}}
    :weighted
    {:add-nodes* (fn [g nodes]
@@ -152,8 +152,14 @@ on adjacency lists."
    (apply dissoc m nodes)
    adjacents))
 
-;; from tools.core
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; aux functions from tools.core
+;;;
 (defn- subj
+  "Conj, disj and subj. Substitution in sets.
+  Does not test for existence of keys that it adds
+  and will happily (subj #{:a :b} [:b :c] [:a :d]) ;=> #{:a}."
   ([s oldk newk] (subj s (apply hash-map (interleave oldk newk))))
   ([s km] (letfn [(subst [s [ok nk]]
                     (if (contains? s ok)
@@ -161,9 +167,10 @@ on adjacency lists."
                           (disj ok)
                           (conj nk))
                       s))]
-            (reduce subst s (seq km)))))
+            (reduce subst s km))))
 
 (defn- rename-keys
+  "Renames keys in a map."
   ([m oldk newk] (rename-keys m (apply hash-map (interleave oldk newk))))
   ([m km] (letfn [(subst [m [ok nk]]
                     (if (contains? m ok)
@@ -171,19 +178,21 @@ on adjacency lists."
                           (dissoc ok)
                           (assoc nk (m ok)))
                       m))]
-            (reduce subst m (seq km)))))
+            (reduce subst m km))))
 
 (defn- updates-in
+  "Runs multiple update-in on a map."
   [m ks f & params]
   (reduce
     #(apply (partial update-in %1 %2 f) params)
     m
     ks))
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (extend BasicEditableGraph
   Graph
   (let [{:keys [all unweighted]} default-graph-impls]
-    (merge all unweighted)) 
+    (merge all unweighted))
 
   EditableGraph
   {:add-nodes*
@@ -229,7 +238,7 @@ on adjacency lists."
 (extend BasicEditableDigraph
   Graph
   (let [{:keys [all unweighted]} default-graph-impls]
-    (merge all unweighted)) 
+    (merge all unweighted))
 
   EditableGraph
   {:add-nodes*
@@ -282,7 +291,7 @@ on adjacency lists."
 (extend BasicEditableWeightedGraph
   Graph
   (let [{:keys [all weighted]} default-graph-impls]
-    (merge all weighted)) 
+    (merge all weighted))
 
   EditableGraph
   {:add-nodes*
@@ -331,7 +340,7 @@ on adjacency lists."
 (extend BasicEditableWeightedDigraph
   Graph
   (let [{:keys [all weighted]} default-graph-impls]
-    (merge all weighted)) 
+    (merge all weighted))
 
   EditableGraph
   {:add-nodes*
@@ -451,8 +460,8 @@ on adjacency lists."
 (defrecord WeightedFlyGraph [fnodes fedges fsuccessors fweight start])
 (defrecord WeightedFlyDigraph [fnodes fedges fsuccessors fpredecessors fweight start])
 
-;; Deprecate the flygraphs?  Instead provide interfaces on algorithms to 
-;; run the algorithm on 
+;; Deprecate the flygraphs?  Instead provide interfaces on algorithms to
+;; run the algorithm on
 
 (extend FlyGraph
   Graph default-flygraph-graph-impl)

--- a/test/loom/test/graph.clj
+++ b/test/loom/test/graph.clj
@@ -1,5 +1,6 @@
 (ns loom.test.graph
   (:use [loom.graph] :reload)
+  (:use [loom.attr] :reload)
   (:use [clojure.test]))
 
 (deftest simple-graph-test
@@ -151,7 +152,23 @@
         g3 (weighted-digraph g1)
         g4 (weighted-digraph g3 (weighted-graph [5 6 88]) [7 8] 9)
         g5 (weighted-digraph)
-        g6 (transpose g1)]
+        g6 (transpose g1)
+        ;;
+        g7 (-> (weighted-digraph)
+               (add-nodes 1 2 3 4)
+               (add-edges [1 3] [2 3] [3 4])
+               (add-attr 1 :type :var)
+               (add-attr 2 :type :val)
+               (add-attr 3 :type :op)
+               (add-attr 4 :type :res)
+               (rename-nodes [3 4] [:a :b]))
+        g8 (-> (weighted-digraph)
+               (add-nodes 1 2 :a :b)
+               (add-edges [1 :a] [2 :a] [:a :b])
+               (add-attr 1 :type :var)
+               (add-attr 2 :type :val)
+               (add-attr :a :type :op)
+               (add-attr :b :type :res))]
     (testing "Construction, nodes, edges"
       (are [expected got] (= expected got)
         #{1 2 3 4} (set (nodes g1))
@@ -196,6 +213,8 @@
         #{[1 2]} (set (edges (remove-nodes g1 3 4)))
         #{1 2 3 4} (set (nodes (remove-edges g1 [1 2] [1 3])))
         #{[2 3]} (set (edges (remove-edges g1 [1 2] [1 3])))))
+    (testing "Rename"
+      (is (= g7 g8)))
     (testing "Weight"
       (are [expected got] (= expected got)
         77 (weight g1 1 2)

--- a/test/loom/test/graph.clj
+++ b/test/loom/test/graph.clj
@@ -1,7 +1,11 @@
 (ns loom.test.graph
   (:use [loom.graph] :reload)
   (:use [loom.attr] :reload)
-  (:use [clojure.test]))
+  (:use [clojure.test])
+  ;; generative testing
+  (:require [clojure.test.check :as tc]
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop]))
 
 (deftest simple-graph-test
   (let [g1 (graph [1 2] [1 3] [2 3] 4)
@@ -270,4 +274,4 @@
         true (weighted? sg)
         #{[1 2] [2 3] [3 4] [4 5]} (set (edges pg))
         #{[1 2] [2 3] [3 1]} (set (edges cg))))))
-    
+


### PR DESCRIPTION
See if this refactoring is a better fit for everyone.
This works for my use case, but there is still the question of what to do if renaming causes nodes/edges to merge. Currently I simply use the union of :adj and :in sets of the two merging nodes, on unweighted graphs. A more general approach might be of interest in weighted case, for sure, and maybe in unweighted as well. Some test.check of different rename-nodes implementations added, as well.

I synced my fork, so it should be easy to see what was added. Let me know what you think.