### PR TITLE
Added ability to choose which attributes get passed to the dot graph node/edge.

### DIFF
--- a/src/loom/io.clj
+++ b/src/loom/io.clj
@@ -81,9 +81,11 @@
       (let [n1l (str (or (node-label n1) n1))
             n2l (str (or (node-label n2) n2))
             el (edge-label n1 n2)
-            eattrs (assoc (if a?
-                            (edge-attrs-fn (attrs g n1 n2)) {})
-                     :label el)]
+            eattrs (edge-attrs-fn
+                    (assoc (if a?
+                             (attrs g n1 n2)
+                             {})
+                      :label el))]
         (doto sb
           (.append "  \"")
           (.append (dot-esc n1l))


### PR DESCRIPTION
I've added the ability to filter out or add additional keys to the attributes of a dot node or a dot edge. 

This is useful as some data is not really part of the loom node/edge but it is meta-data like shape, colour etc. This gives the user a way to add that information if needed.

I've also added a way to add some metadata for the global dot nodes and edges.
