### PR TITLE
Allow for more global attributes in graphviz

### DIFF
--- a/src/loom/io.clj
+++ b/src/loom/io.clj
@@ -56,10 +56,11 @@
                   (if d? "digraph \"" "graph \""))
              (.append (dot-esc graph-name))
              (.append "\" {\n"))]
-    (when (:graph opts)
-      (doto sb
-        (.append "  graph ")
-        (.append (dot-attrs (:graph opts)))))
+    (doseq [k [:graph :node :edge]]
+      (when (k opts)
+        (doto sb
+          (.append (str "  " (name k) " "))
+          (.append (dot-attrs (k opts))))))
     (doseq [[n1 n2] (distinct-edges g)]
       (let [n1l (str (or (node-label n1) n1))
             n2l (str (or (node-label n2) n2))


### PR DESCRIPTION
This commit expands dot-str so that general properties can be assigned
for `node` and `edge`. If more tags are found, it should be easy to add
them in.