### PR TITLE
Add a simple test to verify that the A* implementation is optimal.

### DIFF
--- a/test/loom/test/alg.clj
+++ b/test/loom/test/alg.clj
@@ -487,6 +487,12 @@
        )
   )
 
+(deftest astar-visit-test
+  (let [g (graph [0 1] [1 2] [2 3] [3 4])
+        i (atom 0)]
+    (astar-path g 2 4 (fn [x y] (swap! i inc) (if (> x y) (- x y) (- y x))))
+    (is (= 3 @i) "This implementation of A* is incorrect. It is not optimal.")))
+
 (def degeneracy-g1 (graph {:a [:b]
                            :b [:c :d]}))
 


### PR DESCRIPTION
This test shows that the current A\* implementation is incorrect. It is not optimal.

The problem is that it applies the heuristic function to the current node and each successor node, when it should be applying the heuristic to each successor and the target node.
