### PR TITLE
Fix bugs in A* implementation.

### DIFF
--- a/src/loom/alg.cljc
+++ b/src/loom/alg.cljc
@@ -626,7 +626,7 @@ can use these functions."
                  curr-dist ((second (peek q)) 2)
                  ;; update path
                  explored (assoc explored curr-node ((second (peek q)) 1))
-                 nbrs (remove explored (successors g curr-node))
+                 nbrs (remove (into #{} (keys explored)) (successors g curr-node))
                  ;; we do this for following reasons
                  ;; a. avoiding duplicate heuristics computation
                  ;; b. duplicate entries for nodes, which needs to be removed later
@@ -635,7 +635,7 @@ can use these functions."
                                (let [act (+ curr-dist
                                             (if (weighted? g) (weight g curr-node v) 1))
                                      est (if (nil? (get q v))
-                                           (heur curr-node v) ((get q v) 3))
+                                           (heur v target) ((get q v) 3))
                                   ]
                                  (cond
                                   (or (nil? (get q v))

--- a/test/loom/test/alg.clj
+++ b/test/loom/test/alg.clj
@@ -487,6 +487,12 @@
        )
   )
 
+(deftest astar-visit-test
+  (let [g (graph [0 1] [1 2] [2 3] [3 4])
+        i (atom 0)]
+    (astar-path g 2 4 (fn [x y] (swap! i inc) (if (> x y) (- x y) (- y x))))
+    (is (= 3 @i) "This implementation of A* is incorrect. It is not optimal.")))
+
 (def degeneracy-g1 (graph {:a [:b]
                            :b [:c :d]}))
 


### PR DESCRIPTION
This pull request addresses two bugs in the A\* implementation. 

The explored values were not properly removed from successors to be expanded, so some nodes were revisited during the search. Also, the heuristic function was applied to the incorrect targets as pointed out in #82.

Fixes #82 and incorporates #81.
