### PR TITLE
non-pure map functions in `mapped-by` shouldn't create multiple nodes.

### DIFF
--- a/src/loom/derived.cljc
+++ b/src/loom/derived.cljc
@@ -12,9 +12,12 @@
   edge [uu, vv] is an edge in the resulting graph iff g has an edge [u, v] such
   that [uu, vv] = [(f u), (f v)]."
   [f g]
-  (-> (if (directed? g) (digraph) (graph))
-      (add-nodes* (map f (nodes g)))
-      (add-edges* (map #(map f %) (edges g)))))
+  (let [mapped-nodes (into {} (map (fn [n]
+                                     [n (f n)])
+                                   (nodes g)))]
+    (-> (if (directed? g) (digraph) (graph))
+        (add-nodes* (map mapped-nodes (nodes g)))
+        (add-edges* (map #(map mapped-nodes %) (edges g))))))
 
 (defn subgraph-reachable-from
   "Returns a subgraph of the given graph which contains all nodes and edges that

--- a/test/loom/test/derived.cljc
+++ b/test/loom/test/derived.cljc
@@ -1,7 +1,7 @@
 (ns loom.test.derived
   (:require [loom.derived :refer [mapped-by nodes-filtered-by edges-filtered-by
                                   subgraph-reachable-from bipartite-subgraph]]
-            [loom.graph :refer (graph digraph edges)]
+            [loom.graph :refer (graph digraph edges nodes)]
             [loom.alg :refer (eql?)]
             #?@(:clj [[clojure.test :refer :all]]
                 :cljs [cljs.test]))
@@ -19,6 +19,10 @@
                    (mapped-by inc g))
         true (eql? (graph [2 0] [2 1] [0 1] 2)
                    (mapped-by #(mod % 3) g))
+
+        (count (nodes g)) (let [counter (atom 0)]
+                            (count (nodes (mapped-by (fn [_] (swap! counter inc))
+                                                     g))))
         ;; digraph
         true (eql? dg
                    (mapped-by identity dg))


### PR DESCRIPTION
I had a case where I was mapping over a graph and assoc'ing a uuid onto each. This caused my directed graph to have lots of 'copies' in it, since each call to the mapping function resulted in a different value. The result is a graph with a 2 new nodes per edge.

At first, I thought that changing `mapped-by` might be wrong, since it's generally poor form to use state in map/filter/etc. However, I realized that none of the derived graph functions are lazy, they're all eager, so this probably fits in line with the existing design.

An alternative for me would be the ability to edit/update a node, with semantics similar to `update-in` or `swap!`. An example of that would be:
`(update-node graph node #(assoc % :id (rand-int)))`.