### PR TITLE
use cljdoc for the API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Loom logo](https://raw.github.com/aysylu/loom/master/doc/loom_logo.png "Loom")
 
 [![Build Status](https://travis-ci.org/aysylu/loom.png)](http://travis-ci.org/aysylu/loom)
-
+[![cljdoc badge](https://cljdoc.org/badge/aysylu/loom)](https://cljdoc.org/d/aysylu/loom/CURRENT)
 
 ## Video and Slides
 
@@ -25,7 +25,7 @@ Watch the talk on Loom [at Clojure/West 2014](https://www.youtube.com/watch?v=wE
 
 ### Documentation
 
-[API Reference](http://aysy.lu/loom/)
+[API Reference](https://cljdoc.org/d/aysylu/loom/CURRENT)
 
 [Frequently Asked Questions](http://aysy.lu/loom/faq.html)
 

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
   :test-selectors {:default (fn [m] (not (:test-check-slow m)))
                    :all (constantly true)
                    :test-check-slow :test-check-slow}
-  
+
   :profiles {:dev [:cljs
                    {:dependencies [[org.clojure/test.check "0.9.0"]]
                     :plugins [[com.jakemccrary/lein-test-refresh "0.15.0"]]
@@ -36,12 +36,7 @@
                                              :pretty-print false
                                              :target :nodejs
                                              :main loom.test.runner}}}}}}
-  
+
   :aliases {"test-all" ["do" "clean," "test" ":all," "cljs-test"]
             "cljs-test" ["doo" "node" "node-test" "once"]
-            "release" ["do" "clean," "with-profile" "default" "deploy" "clojars"]}
-
-  :plugins  [[codox "0.8.12"]]
-  :codox  {:src-dir-uri "https://github.com/aysylu/loom/blob/master/"
-           :src-linenum-anchor-prefix "L"
-           :exclude loom.multigraph})
+            "release" ["do" "clean," "with-profile" "default" "deploy" "clojars"]})


### PR DESCRIPTION
Documentation is already being rendered in cljdoc nicely, so you can just use that for the API reference.