### PR TITLE
upgrade jdks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: clojure
 script: lein test-all
 jdk:
-  - openjdk7
-  - oraclejdk7
+  - openjdk8
   - oraclejdk8
+  - oraclejdk9
+  - oraclejdk10
+  - oraclejdk11


### PR DESCRIPTION
oraclejdk7 doesn't seem to be supported anymore by travis, update it and add a few more.