### PR TITLE
Support empty maps

### DIFF
--- a/src/loom/graph.cljc
+++ b/src/loom/graph.cljc
@@ -496,16 +496,18 @@ on adjacency lists."
                    (assoc :attrs (merge (:attrs g) (:attrs init)))))
              ;; adacency map
              (map? init)
-             (let [es (if (map? (val (first init)))
-                        (for [[n nbrs] init
-                              [nbr wt] nbrs]
-                          [n nbr wt])
-                        (for [[n nbrs] init
-                              nbr nbrs]
-                          [n nbr]))]
-               (-> g
-                   (add-nodes* (keys init))
-                   (add-edges* es)))
+             (if (empty? init)
+               g
+               (let [es (if (map? (val (first init)))
+                          (for [[n nbrs] init
+                                [nbr wt] nbrs]
+                            [n nbr wt])
+                          (for [[n nbrs] init
+                                nbr nbrs]
+                            [n nbr]))]
+                 (-> g
+                     (add-nodes* (keys init))
+                     (add-edges* es))))
              ;; edge
              (sequential? init) (add-edges g init)
              ;; node

--- a/test/loom/test/graph.cljc
+++ b/test/loom/test/graph.cljc
@@ -20,7 +20,8 @@
         g2 (graph {1 [2 3] 2 [3] 4 []})
         g3 (graph g1)
         g4 (graph g3 (digraph [5 6]) [7 8] 9)
-        g5 (graph)]
+        g5 (graph)
+        g6 (graph {})]
     (testing "Construction, nodes, edges"
       (are [expected got] (= expected got)
            #{1 2 3 4} (set (nodes g1))
@@ -34,6 +35,8 @@
              [3 2] [5 6] [6 5] [7 8] [8 7]} (set (edges g4))
              #{} (set (nodes g5))
              #{} (set (edges g5))
+             #{} (set (nodes g6))
+             #{} (set (edges g6))
              true (has-node? g1 4)
              true (has-edge? g1 1 2)
              false (has-node? g1 5)


### PR DESCRIPTION
Before:
```
(loom.graph/graph {})
Execution error (NullPointerException) at loom.graph/build-graph$build (graph.cljc:499).
null
```
After:
```
(loom.graph/graph {})
=> #loom.graph.BasicEditableGraph{:nodeset #{}, :adj {}}
```
Of course you could call `(loom.graph/graph)` instead but the point is to remove a pitfall when dealing with maps.