### PR TITLE
Fix io view

### DIFF
--- a/src/loom/io.clj
+++ b/src/loom/io.clj
@@ -64,27 +64,22 @@
     (doseq [edge (distinct-edges g)]
       (let [n1 (src edge)
             n2 (dest edge)
-            n1l (str (or (node-label n1) n1))
-            n2l (str (or (node-label n2) n2))
             el (edge-label n1 n2)
             eattrs (assoc (if a?
                             (attrs g n1 n2) {})
                      :label el)]
         (doto sb
-          (.append "  \"")
-          (.append (dot-esc n1l))
-          (.append (if d? "\" -> \"" "\" -- \""))
-          (.append (dot-esc n2l))
-          (.append \"))
+          (.append (str (hash n1)))
+          (.append (if d? " -> " " -- "))
+          (.append (str (hash n2))))
         (when (or (:label eattrs) (< 1 (count eattrs)))
           (.append sb \space)
           (.append sb (dot-attrs eattrs)))
         (.append sb "\n")))
     (doseq [n (nodes g)]
-      (doto sb
-        (.append "  \"")
-        (.append (dot-esc (str (or (node-label n) n))))
-        (.append \"))
+      (let [nl (dot-esc (str (or (node-label n) n)))]
+        (doto sb
+          (.append (str (hash n) " [label=\"" nl "\"]"))))
       (when-let [nattrs (when a?
                           (dot-attrs (attrs g n)))]
         (.append sb \space)

--- a/src/loom/io.clj
+++ b/src/loom/io.clj
@@ -1,7 +1,7 @@
 (ns ^{:doc "Output and view graphs in various formats"
       :author "Justin Kramer"}
   loom.io
-  (:require [loom.graph :refer [directed? weighted? nodes edges weight]]
+  (:require [loom.graph :refer [directed? weighted? nodes edges weight src dest]]
             [loom.alg :refer [distinct-edges loners]]
             [loom.attr :refer [attr? attr attrs]]
             [clojure.string :refer [escape]]
@@ -61,8 +61,10 @@
         (doto sb
           (.append (str "  " (name k) " "))
           (.append (dot-attrs (k opts))))))
-    (doseq [[n1 n2] (distinct-edges g)]
-      (let [n1l (str (or (node-label n1) n1))
+    (doseq [edge (distinct-edges g)]
+      (let [n1 (src edge)
+            n2 (dest edge)
+            n1l (str (or (node-label n1) n1))
             n2l (str (or (node-label n2) n2))
             el (edge-label n1 n2)
             eattrs (assoc (if a?


### PR DESCRIPTION
This PR fixes two problems with the current implementation of `loom.io/dot-str` which affect viewing graphs with `loom.io/view`. These are long-standing issues that I have had to [circumvent in my own code](https://github.com/simongray/datalinguist/blob/master/src/dk/simongray/datalinguist/loom/io.clj).

This PR undoes these two issues:

* Loom now uses the Loom Edge protocol rather than destructuring a Clojure vector.
* Loom now uses the hash of a node as its identity, rather than the node label when building the dot string.

The current behaviour make Loom quite pointless for visualising graphs since Loom doesn't even respect its own graph protocols, preferring to assume that e.g. graph edges are always Clojure vectors. It also results in wrong graphs being drawn since Loom complects node labels and node identity, when clearly it must be possible for two nodes to have the same label in a graph.