### PR TITLE
Support HTML string as a attr value

### DIFF
--- a/src/loom/io.clj
+++ b/src/loom/io.clj
@@ -4,7 +4,7 @@
   (:require [loom.graph :refer [directed? weighted? nodes edges weight src dest]]
             [loom.alg :refer [distinct-edges loners]]
             [loom.attr :refer [attr? attr attrs]]
-            [clojure.string :refer [escape]]
+            [clojure.string :refer [escape] :as str]
             [clojure.java.io :refer [file]]
             [clojure.java.shell :refer [sh]])
   (:import (java.io FileWriter
@@ -19,15 +19,19 @@
   (when (seq attrs)
     (let [sb (StringBuilder. "[")]
       (doseq [[k v] attrs]
-        (when (pos? (.length (str v)))
-          (when (< 1 (.length sb))
-            (.append sb \,))
-          (doto sb
-            (.append \")
-            (.append (dot-esc (if (keyword? k) (name k) (str k))))
-            (.append "\"=\"")
-            (.append (dot-esc (if (keyword? v) (name v) (str v))))
-            (.append \"))))
+        (let [v (dot-esc (if (keyword? v) (name v) (str v)))
+              html-string? (and (str/starts-with? v "<") (str/ends-with? v ">"))
+              attr-val-open (if html-string? "\"=" "\"=\"")
+              attr-val-close (if html-string? "" \")]
+          (when (pos? (.length (str v)))
+            (when (< 1 (.length sb))
+              (.append sb \,))
+            (doto sb
+              (.append \")
+              (.append (dot-esc (if (keyword? k) (name k) (str k))))
+              (.append attr-val-open)
+              (.append v)
+              (.append attr-val-close)))))
       (.append sb "]")
       (str sb))))
 

--- a/test/loom/test/io.cljc
+++ b/test/loom/test/io.cljc
@@ -1,0 +1,13 @@
+(ns loom.test.io
+    (:require [loom.graph :refer (digraph)]
+              [loom.attr :refer (add-attr attr add-attr-to-nodes add-attr-to-edges)]
+              [loom.io :refer (dot-str)]
+              #?@(:clj [[clojure.test :refer :all]]))
+    #?@(:cljs [(:require-macros [cljs.test :refer (deftest testing are is)])]))
+
+(deftest support-html-label-test
+  (let [g (digraph [1 2])
+        lg1 (-> g
+                (add-attr 1 :label "node1 label")
+                (add-attr 2 :label "<node2 label>"))]
+    (is (= "digraph \"graph\" {\n1392991556 -> -971005196\n1392991556 [label=\"node1 label\"] [\"label\"=\"node1 label\"]\n-971005196 [label=\"<node2 label>\"] [\"label\"=<node2 label>]\n}" (dot-str lg1)))))

--- a/test/loom/test/runner.cljs
+++ b/test/loom/test/runner.cljs
@@ -7,6 +7,7 @@
             loom.test.derived
             loom.test.flow
             loom.test.graph
-            loom.test.label))
+            loom.test.label
+            loom.test.io))
 
 (doo-all-tests)


### PR DESCRIPTION
Specially useful for labels. value is a HTML string if it is between
`<...>` and can not be wrapped in dbl quotes.

See https://graphviz.org/doc/info/shapes.html#html